### PR TITLE
Update code to fix compilation warning/error due to deprecated/deleted method

### DIFF
--- a/src/raspiSonar.cc
+++ b/src/raspiSonar.cc
@@ -2,6 +2,7 @@
 #include <nan.h>
 #include "sonarWorker.h"
 
+using v8::Context;
 using v8::Function;
 using v8::Local;
 using v8::Number;
@@ -43,7 +44,8 @@ public:
             const int argc = 1;
             v8::Local<v8::Value> argv[argc] = {info[0]};
             v8::Local<v8::Function> cons = Nan::New(constructor());
-            info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+            Local<Context> context = info.GetIsolate()->GetCurrentContext();
+            info.GetReturnValue().Set(cons->NewInstance(context, argc, argv).ToLocalChecked());
         }
     }
 


### PR DESCRIPTION
Following [this example](https://github.com/nodejs/node/commit/8f526494b5#diff-cfe02a59cd62ae51d90d95e1e92626e7R557) I use a new `NewINstance` method which takes a context object to fix a compilation error on newer versions of node/v8.